### PR TITLE
Introduce the -reopen flag to allow logrotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ nohup ./slackd -config=config.ini &
 
 USAGE
 -----
-The application is self documented, so you can review the usage at any time.  
+The application is self documented, so you can review the usage at any time.
 
 ```
 $ ./slackd -h
@@ -34,6 +34,7 @@ Usage of ./slackd:
   -line_excludes="": Post line if this regexp DOES NOT match
   -line_includes="": Post line if this regexp DOES match
   -token="": Your Slack token
+  -reopen: Should we try to reopen the file if it disappears? Useful with logrotation or programs that recreate logs
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -52,4 +52,5 @@ channel = errors
 file = /var/log/application.log
 line_includes = (?i)error
 line_excludes = ^[0-9]{4}/[0-9]{2}/[0-9]{2}
+reopen = true
 ```

--- a/slackd.go
+++ b/slackd.go
@@ -17,6 +17,7 @@ var (
 	file     = flag.String("file", "", "The file path to watch for changes")
 	includes = flag.String("line_includes", "", "Post line if this regexp DOES match")
 	excludes = flag.String("line_excludes", "", "Post line if this regexp DOES NOT match")
+	reopen   = flag.Bool("reopen", false, "Reopen the file if it disappears. Useful with logrotation")
 )
 
 func getChannelId(name string, api *slack.Client) string {
@@ -93,7 +94,7 @@ func main() {
 		}
 	}
 
-	log, err := tail.TailFile(*file, tail.Config{Follow: true})
+	log, err := tail.TailFile(*file, tail.Config{Follow: true, ReOpen: *reopen})
 	if err != nil {
 		fmt.Println("ERROR: Could not tail the specified log.")
 		fmt.Println(err)


### PR DESCRIPTION
The hpcloud/tail library allows for a `ReOpen` parameter, so I added a flag for it which defaults to false to keep the current behavior.

I've not yet found a way to abort it after $x time, as of now it will wait forever.

Before:
```
./slackd -config config.ini                                                                                 
2016/11/11 08:56:32 Stopping tail as file no longer exists: logfile.log
```

After:
```
./slackd -config config.ini -reopen                                                                            
2016/11/11 08:57:18 Re-opening moved/deleted file logfile.log ...
2016/11/11 08:57:18 Waiting for logfile.log to appear...
2016/11/11 08:57:18 Successfully reopened logfile.log
```